### PR TITLE
Fix for a private key without a password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `crypto` will be documented in this file
 
+## 2.0.1 - 2022-02-15
+
+- Fix possibility of "Enter PEM pass phrase:" to occur (#10)
+
+
 ## 2.0.0 - 2020-12-03
 
 - use `OPENSSL_ALGO_SHA256` for signing and verifying data

--- a/src/Rsa/PrivateKey.php
+++ b/src/Rsa/PrivateKey.php
@@ -29,7 +29,14 @@ class PrivateKey
 
     public function __construct(string $privateKeyString, string $password = null)
     {
-        $this->privateKey = openssl_pkey_get_private($privateKeyString, $password);
+        /**
+         * When you try to get a private key that has a password and you supply a null
+         * value password then it is possible that a prompt of "Enter PEM pass phrase:" occurs.
+         * The solution is to not supply any password variable.
+         */
+        $this->privateKey = $password ?
+            openssl_pkey_get_private($privateKeyString, $password) :
+            openssl_pkey_get_private($privateKeyString);
 
         if ($this->privateKey === false) {
             throw InvalidPrivateKey::make();

--- a/tests/Rsa/PrivateKeyTest.php
+++ b/tests/Rsa/PrivateKeyTest.php
@@ -5,6 +5,7 @@ namespace Spatie\Crypto\Tests\Rsa;
 use Spatie\Crypto\Rsa\Exceptions\CouldNotDecryptData;
 use Spatie\Crypto\Rsa\Exceptions\FileDoesNotExist;
 use Spatie\Crypto\Rsa\Exceptions\InvalidPrivateKey;
+use Spatie\Crypto\Rsa\KeyPair;
 use Spatie\Crypto\Rsa\PrivateKey;
 use Spatie\Crypto\Rsa\PublicKey;
 use Spatie\Crypto\Tests\TestCase;
@@ -61,5 +62,15 @@ class PrivateKeyTest extends TestCase
         $privateKey = PrivateKey::fromFile($this->getStub('privateKey'));
 
         $this->assertTrue($privateKey->canDecrypt($encryptedData));
+    }
+
+    public function test_instantiating_a_private_key_that_has_password_with_no_password_should_throw_exception()
+    {
+        $this->expectException(InvalidPrivateKey::class);
+
+        $password = "super-strong-password";
+        [$passwordProtectedPrivateKey, $publicKey] = (new KeyPair())->password($password)->generate();
+
+        PrivateKey::fromString($passwordProtectedPrivateKey);
     }
 }


### PR DESCRIPTION
When you try to get a private key that has a password and you supply a null value password then it is possible that a prompt of "Enter PEM pass phrase:" occurs.

The solution is to not supply any password variable.

I believe this is the fix to this issue #10 

This is also covered by a test and I have added it into the changelog. I left a big comment in the code because it is just not obvious why this is being done.