### PR TITLE
Widen "digestAlgorithm" to fix strict typing error.

### DIFF
--- a/src/Rsa/KeyPair.php
+++ b/src/Rsa/KeyPair.php
@@ -11,13 +11,13 @@ class KeyPair
     private ?string $password = null;
 
     public function __construct(
-        string $digestAlgorithm = OPENSSL_ALGO_SHA512,
+        $digestAlgorithm = OPENSSL_ALGO_SHA512,
         int $privateKeyBits = 4096,
         int $privateKeyType = OPENSSL_KEYTYPE_RSA
     ) {
         $this->privateKeyType = $privateKeyType;
         $this->privateKeyBits = $privateKeyBits;
-        $this->digestAlgorithm = $digestAlgorithm;
+        $this->digestAlgorithm = (string)$digestAlgorithm;
     }
 
     public function password(string $password = null): self

--- a/tests/Rsa/KeyPairTest.php
+++ b/tests/Rsa/KeyPairTest.php
@@ -1,5 +1,4 @@
 <?php
-declare(strict_types = 1);
 
 namespace Spatie\Crypto\Tests\Rsa;
 

--- a/tests/Rsa/KeyPairTest.php
+++ b/tests/Rsa/KeyPairTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types = 1);
 
 namespace Spatie\Crypto\Tests\Rsa;
 


### PR DESCRIPTION
This is a PR to expose an issue I hit locally. Where running this in a project where strict_types is enabled results in.

```
   TypeError 

  Spatie\Crypto\Rsa\KeyPair::__construct(): Argument #1 ($digestAlgorithm) must be of type string, int given, called in /code/app/Actions/Configuration/CreateKeyPairAction.php on line 31

  at vendor/spatie/crypto/src/Rsa/KeyPair.php:13
      9▕     protected int $privateKeyType;
     10▕ 
     11▕     private ?string $password = null;
     12▕ 
  ➜  13▕     public function __construct(
     14▕         string $digestAlgorithm = OPENSSL_ALGO_SHA512,
```

So I'm not sure what path to take here in this repo, but willing to do any of them:

1. Support `int|string` and cast to what is needed.
2. Remove `string` and make `digest` only `int` (breaking change?).
3. Add strict types to all files, implement point 2 as well and fix any other discovered type casting issue.
4. drop php7.4, move to 8+ only and implement point 2 and 3 for a major breaking new version.