### PR TITLE
Explicitly mark parameters as nullable

### DIFF
--- a/src/Rsa/KeyPair.php
+++ b/src/Rsa/KeyPair.php
@@ -20,7 +20,7 @@ class KeyPair
         $this->digestAlgorithm = (string)$digestAlgorithm;
     }
 
-    public function password(string $password = null): self
+    public function password(?string $password = null): self
     {
         $this->password = $password;
 

--- a/src/Rsa/PrivateKey.php
+++ b/src/Rsa/PrivateKey.php
@@ -11,12 +11,12 @@ class PrivateKey
     /** @var resource */
     protected $privateKey;
 
-    public static function fromString(string $privateKeyString, string $password = null): self
+    public static function fromString(string $privateKeyString, ?string $password = null): self
     {
         return new static($privateKeyString, $password);
     }
 
-    public static function fromFile(string $pathToPrivateKey, string $password = null): self
+    public static function fromFile(string $pathToPrivateKey, ?string $password = null): self
     {
         if (! file_exists($pathToPrivateKey)) {
             throw FileDoesNotExist::make($pathToPrivateKey);
@@ -27,7 +27,7 @@ class PrivateKey
         return new static($privateKeyString, $password);
     }
 
-    public function __construct(string $privateKeyString, string $password = null)
+    public function __construct(string $privateKeyString, ?string $password = null)
     {
         /**
          * When you try to get a private key that has a password and you supply a null


### PR DESCRIPTION
Ever since PHP version 8.4, implicitly marking parameter as nullable by passing null as the default value is deprecated behavior. 

This PR explicitly marks such parameters as nullable to avoid deprecation notices.